### PR TITLE
CGE-111 BugFix Email validation when registering new user

### DIFF
--- a/src/main/java/com/hillel/items_exchange/controller/AuthController.java
+++ b/src/main/java/com/hillel/items_exchange/controller/AuthController.java
@@ -1,10 +1,19 @@
 package com.hillel.items_exchange.controller;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.validation.Valid;
-
+import com.hillel.items_exchange.dto.UserLoginDto;
+import com.hillel.items_exchange.dto.UserRegistrationDto;
+import com.hillel.items_exchange.exception.BadRequestException;
+import com.hillel.items_exchange.exception.RoleNotFoundException;
+import com.hillel.items_exchange.exception.UserValidationException;
+import com.hillel.items_exchange.model.Role;
+import com.hillel.items_exchange.model.User;
+import com.hillel.items_exchange.security.jwt.JwtTokenProvider;
+import com.hillel.items_exchange.service.RoleService;
+import com.hillel.items_exchange.service.UserService;
+import com.hillel.items_exchange.validator.UserLoginDtoValidator;
+import com.hillel.items_exchange.validator.UserRegistrationDtoValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -13,27 +22,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import com.hillel.items_exchange.dto.UserLoginDto;
-import com.hillel.items_exchange.dto.UserRegistrationDto;
-import com.hillel.items_exchange.exception.BadRequestException;
-import com.hillel.items_exchange.exception.UserValidationException;
-import com.hillel.items_exchange.exception.RoleNotFoundException;
-import com.hillel.items_exchange.model.Role;
-import com.hillel.items_exchange.model.User;
-import com.hillel.items_exchange.security.jwt.JwtTokenProvider;
-import com.hillel.items_exchange.service.RoleService;
-import com.hillel.items_exchange.service.UserService;
-import com.hillel.items_exchange.validator.UserLoginDtoValidator;
-import com.hillel.items_exchange.validator.UserRegistrationDtoValidator;
+import javax.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.hillel.items_exchange.util.MessageSourceUtil.getExceptionMessageSource;
 import static com.hillel.items_exchange.util.MessageSourceUtil.getExceptionMessageSourceWithAdditionalInfo;
@@ -85,9 +78,6 @@ public class AuthController {
     @PostMapping("/register")
     public ResponseEntity<HttpStatus> registerUser(@RequestBody @Valid UserRegistrationDto userRegistrationDto, BindingResult bindingResult) {
         userRegistrationDtoValidator.validate(userRegistrationDto, bindingResult);
-        if (bindingResult.hasErrors()) {
-            throw new UserValidationException(bindingResult.toString());
-        }
 
         Role role = roleService.getRole(ROLE_USER).orElseThrow(RoleNotFoundException::new);
         if (userService.registerNewUser(userRegistrationDto, role)) {

--- a/src/main/java/com/hillel/items_exchange/dto/UserRegistrationDto.java
+++ b/src/main/java/com/hillel/items_exchange/dto/UserRegistrationDto.java
@@ -22,7 +22,7 @@ public class UserRegistrationDto {
 
     @NotEmpty(message = "{empty.email}")
     @Size(max = 129, message = "{too.big.email}")
-    @Email(regexp = PatternHandler.EMAIL, message = "{invalid.email}")
+    @Email(message = "{invalid.email}")
     private String email;
 
     @NotEmpty(message = "{empty.password}")

--- a/src/main/java/com/hillel/items_exchange/validator/UserRegistrationDtoValidator.java
+++ b/src/main/java/com/hillel/items_exchange/validator/UserRegistrationDtoValidator.java
@@ -1,17 +1,16 @@
 package com.hillel.items_exchange.validator;
 
-import java.util.Objects;
-
-import org.springframework.stereotype.Component;
-import org.springframework.validation.Errors;
-import org.springframework.validation.Validator;
-
-import lombok.RequiredArgsConstructor;
-
 import com.hillel.items_exchange.dto.UserRegistrationDto;
 import com.hillel.items_exchange.exception.BadRequestException;
 import com.hillel.items_exchange.exception.UnprocessableEntityException;
 import com.hillel.items_exchange.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.Validator;
+
+import java.util.Objects;
 
 import static com.hillel.items_exchange.util.MessageSourceUtil.getExceptionMessageSource;
 
@@ -40,6 +39,11 @@ public class UserRegistrationDtoValidator implements Validator {
 
         if (!Objects.equals(userRegistrationDto.getConfirmPassword(), userRegistrationDto.getPassword())) {
             throw new BadRequestException(getExceptionMessageSource("different.passwords"));
+        }
+
+        final FieldError emailError = errors.getFieldError("email");
+        if (emailError!=null){
+            throw new BadRequestException(emailError.getDefaultMessage());
         }
     }
 }


### PR DESCRIPTION
According to RFC 5321 specification the format of email addresses is **local-part**@**domain** where the local part may be up to 64 octets long and the domain may have a maximum of 255 octets. (4.5.3.1.1.  Local-part, 4.5.3.1.2.  Domain).
Was changed:
- refactored exception handling of email validation
