### PR TITLE
CGE-111 BugFix Email validation when registering new user

### DIFF
--- a/src/main/java/com/hillel/items_exchange/controller/AuthController.java
+++ b/src/main/java/com/hillel/items_exchange/controller/AuthController.java
@@ -85,9 +85,6 @@ public class AuthController {
     @PostMapping("/register")
     public ResponseEntity<HttpStatus> registerUser(@RequestBody @Valid UserRegistrationDto userRegistrationDto, BindingResult bindingResult) {
         userRegistrationDtoValidator.validate(userRegistrationDto, bindingResult);
-        if (bindingResult.hasErrors()) {
-            throw new UserValidationException(bindingResult.toString());
-        }
 
         Role role = roleService.getRole(ROLE_USER).orElseThrow(RoleNotFoundException::new);
         if (userService.registerNewUser(userRegistrationDto, role)) {

--- a/src/main/java/com/hillel/items_exchange/dto/UserRegistrationDto.java
+++ b/src/main/java/com/hillel/items_exchange/dto/UserRegistrationDto.java
@@ -22,7 +22,7 @@ public class UserRegistrationDto {
 
     @NotEmpty(message = "{empty.email}")
     @Size(max = 129, message = "{too.big.email}")
-    @Email(regexp = PatternHandler.EMAIL, message = "{invalid.email}")
+    @Email(message = "{invalid.email}")
     private String email;
 
     @NotEmpty(message = "{empty.password}")

--- a/src/main/java/com/hillel/items_exchange/validator/UserRegistrationDtoValidator.java
+++ b/src/main/java/com/hillel/items_exchange/validator/UserRegistrationDtoValidator.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
 import org.springframework.validation.Validator;
 
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,11 @@ public class UserRegistrationDtoValidator implements Validator {
 
         if (!Objects.equals(userRegistrationDto.getConfirmPassword(), userRegistrationDto.getPassword())) {
             throw new BadRequestException(getExceptionMessageSource("different.passwords"));
+        }
+
+        final FieldError emailError = errors.getFieldError("email");
+        if (emailError!=null){
+            throw new BadRequestException(emailError.getDefaultMessage());
         }
     }
 }


### PR DESCRIPTION
According to RFC 5321 specification the format of email addresses is local-part@domain where the local part may be up to 64 octets long and the domain may have a maximum of 255 octets. (4.5.3.1.1. Local-part, 4.5.3.1.2. Domain).
Was changed:
- refactored exception handling of email validation