### PR TITLE
Cge 116 fix empty description bug

### DIFF
--- a/src/main/java/com/hillel/items_exchange/dto/AdvertisementDto.java
+++ b/src/main/java/com/hillel/items_exchange/dto/AdvertisementDto.java
@@ -23,7 +23,7 @@ public class AdvertisementDto {
     @NotEmpty(message = "{invalid.not-empty}")
     @Size(min = 3, max = 70, message = "{invalid.size}")
     private String topic;
-    @ApiModelProperty
+    @ApiModelProperty(value = "can't be null, but can be empty")
     @NotNull(message = "{invalid.not-null}")
     @Size(max = 255, message = "{invalid.max-size}")
     private String description;

--- a/src/main/java/com/hillel/items_exchange/dto/AdvertisementDto.java
+++ b/src/main/java/com/hillel/items_exchange/dto/AdvertisementDto.java
@@ -1,6 +1,7 @@
 package com.hillel.items_exchange.dto;
 
 import com.hillel.items_exchange.model.DealType;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
 import javax.validation.Valid;
@@ -21,6 +22,8 @@ public class AdvertisementDto {
     @NotEmpty(message = "{invalid.not-empty}")
     @Size(min = 3, max = 70, message = "{invalid.size}")
     private String topic;
+    @ApiModelProperty
+    @NotNull(message = "{invalid.not-null}")
     @Size(max = 255, message = "{invalid.max-size}")
     private String description;
     @NotNull(message = "{invalid.not-null}")

--- a/src/main/java/com/hillel/items_exchange/dto/AdvertisementDto.java
+++ b/src/main/java/com/hillel/items_exchange/dto/AdvertisementDto.java
@@ -21,7 +21,6 @@ public class AdvertisementDto {
     @NotEmpty(message = "{invalid.not-empty}")
     @Size(min = 3, max = 70, message = "{invalid.size}")
     private String topic;
-    @NotEmpty(message = "{invalid.not-empty}")
     @Size(max = 255, message = "{invalid.max-size}")
     private String description;
     @NotNull(message = "{invalid.not-null}")

--- a/src/main/java/com/hillel/items_exchange/dto/AdvertisementDto.java
+++ b/src/main/java/com/hillel/items_exchange/dto/AdvertisementDto.java
@@ -19,6 +19,7 @@ import javax.validation.constraints.Size;
 public class AdvertisementDto {
     @PositiveOrZero(message = "{invalid.id}")
     private long id;
+    @ApiModelProperty(required = true)
     @NotEmpty(message = "{invalid.not-empty}")
     @Size(min = 3, max = 70, message = "{invalid.size}")
     private String topic;


### PR DESCRIPTION
Bug: There is no possibility to create advertisement which contain only obligatory fields accoding Swagger.
Fix: Field Topic marked as obligatory, field description can't be null, but can be empty( setted description in swagger ).