### PR TITLE
[OBMIN-69] A new endpoint created for returning random 12 advertisements

### DIFF
--- a/src/main/java/space/obminyashka/items_exchange/config/AppConfig.java
+++ b/src/main/java/space/obminyashka/items_exchange/config/AppConfig.java
@@ -1,6 +1,7 @@
 package space.obminyashka.items_exchange.config;
 
 import org.modelmapper.ModelMapper;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import org.springframework.web.servlet.i18n.AcceptHeaderLocaleResolver;
 
 @Configuration
 @EnableJpaAuditing(dateTimeProviderRef = "dateTimeProvider")
+@EnableCaching
 @EnableScheduling
 public class AppConfig {
 

--- a/src/main/java/space/obminyashka/items_exchange/controller/AdvertisementController.java
+++ b/src/main/java/space/obminyashka/items_exchange/controller/AdvertisementController.java
@@ -68,6 +68,18 @@ public class AdvertisementController {
                 new ResponseEntity<>(dtoList, HttpStatus.OK);
     }
 
+    @GetMapping("/thumbnail/random")
+    @ApiOperation(value = "Find 12 random advertisement as thumbnails and return them as a result")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "OK"),
+            @ApiResponse(code = 404, message = "Database is empty")})
+    public ResponseEntity<List<AdvertisementTitleDto>> findRandom12Thumbnails() {
+        final var dtoList = advertisementService.findRandom12Thumbnails();
+        return dtoList.isEmpty() ?
+                new ResponseEntity<>(HttpStatus.NOT_FOUND) :
+                new ResponseEntity<>(dtoList, HttpStatus.OK);
+    }
+
     @GetMapping("/{advertisement_id}")
     @ApiOperation(value = "Find an advertisement by its ID")
     @ApiResponses(value = {

--- a/src/main/java/space/obminyashka/items_exchange/service/AdvertisementService.java
+++ b/src/main/java/space/obminyashka/items_exchange/service/AdvertisementService.java
@@ -1,10 +1,13 @@
 package space.obminyashka.items_exchange.service;
 
 import org.springframework.data.domain.Page;
-import space.obminyashka.items_exchange.dto.*;
+import org.springframework.data.domain.Pageable;
+import space.obminyashka.items_exchange.dto.AdvertisementDisplayDto;
+import space.obminyashka.items_exchange.dto.AdvertisementFilterDto;
+import space.obminyashka.items_exchange.dto.AdvertisementModificationDto;
+import space.obminyashka.items_exchange.dto.AdvertisementTitleDto;
 import space.obminyashka.items_exchange.model.Advertisement;
 import space.obminyashka.items_exchange.model.User;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +20,12 @@ public interface AdvertisementService {
      * @return wanted quantity of advertisement on a page
      */
     List<AdvertisementTitleDto> findAllThumbnails(Pageable pageable);
+
+    /**
+     * Find 12 random advertisements as thumbnails
+     * @return random 12 advertisement
+     */
+    List<AdvertisementTitleDto> findRandom12Thumbnails();
 
     /**
      * Find all advertisements as thumbnails for specific user

--- a/src/main/resources/react/src/REST/Resources/fetchHome.js
+++ b/src/main/resources/react/src/REST/Resources/fetchHome.js
@@ -1,5 +1,5 @@
 import { obminyashkaApi } from '../Service/networkProvider';
 
 export const getCurrentOffers = () => {
-  return obminyashkaApi.get(`/adv/thumbnail`);
+  return obminyashkaApi.get(`/adv/thumbnail/random`);
 };

--- a/src/test/java/space/obminyashka/items_exchange/BasicControllerTest.java
+++ b/src/test/java/space/obminyashka/items_exchange/BasicControllerTest.java
@@ -29,6 +29,7 @@ public abstract class BasicControllerTest {
     protected static final String ADV_ID = ADV + "/{advertisement_id}";
     protected static final String ADV_FILTER = ADV + "/filter";
     protected static final String ADV_THUMBNAIL = ADV + "/thumbnail";
+    protected static final String ADV_THUMBNAIL_RANDOM = ADV + "/thumbnail/random";
     protected static final String ADV_THUMBNAIL_PARAMS = ADV_THUMBNAIL + "?page={page}&size={size}";
     // Authorization API
     protected static final String AUTH = API + "/auth";

--- a/src/test/java/space/obminyashka/items_exchange/end2end/AdvertisementFlowTest.java
+++ b/src/test/java/space/obminyashka/items_exchange/end2end/AdvertisementFlowTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -102,13 +103,14 @@ class AdvertisementFlowTest extends BasicControllerTest {
                 .andExpect(jsonPath("$[0].ownerName").value("admin"));
     }
 
-    @Test
+    @ParameterizedTest
     @DisplayName("Should return all advertisements from DB (12 if there is more)")
+    @ValueSource(strings = {ADV_THUMBNAIL, ADV_THUMBNAIL_RANDOM})
     @WithMockUser(username = "admin")
     @DataSet("database_init.yml")
-    void findPaginatedAsThumbnails_shouldReturnProperQuantityOfAdvertisementsThumbnails() throws Exception {
-        sendUriAndGetResultAction(get(ADV_THUMBNAIL), status().isOk())
-                .andExpect(jsonPath("$.length()").value(advertisementRepository.findAll().size()));
+    void findPaginatedAsThumbnails_shouldReturnProperQuantityOfAdvertisementsThumbnails(String api) throws Exception {
+        sendUriAndGetResultAction(get(api), status().isOk())
+                .andExpect(jsonPath("$.length()").value(advertisementRepository.count()));
     }
 
     @Test

--- a/src/test/java/space/obminyashka/items_exchange/service/AdvertisementServiceIntegrationTest.java
+++ b/src/test/java/space/obminyashka/items_exchange/service/AdvertisementServiceIntegrationTest.java
@@ -1,0 +1,39 @@
+package space.obminyashka.items_exchange.service;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.junit5.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import space.obminyashka.items_exchange.dao.AdvertisementRepository;
+
+import javax.transaction.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@DBRider
+@Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, scripts = "classpath:index-reset.sql")
+class AdvertisementServiceIntegrationTest {
+    @Autowired
+    private AdvertisementRepository repository;
+    @Autowired
+    private AdvertisementService advertisementService;
+
+    @Test
+    @Transactional
+    @DataSet("database_init.yml")
+    void findRandom12Thumbnails_shouldReturnEmpty() {
+
+        final var firstTitlesGetAttempt = advertisementService.findRandom12Thumbnails();
+
+        assertAll("Validation of all parameters and mocks",
+                () -> assertFalse(firstTitlesGetAttempt.isEmpty()),
+                () -> assertEquals(repository.count(), firstTitlesGetAttempt.size())
+        );
+
+        final var secondTitlesGetAttempt = advertisementService.findRandom12Thumbnails();
+        assertEquals(firstTitlesGetAttempt, secondTitlesGetAttempt, "Collections must be equals because of caching response");
+    }
+}


### PR DESCRIPTION
- A new REST endpoint "/api/v1/adv/thumbnail/random" is created and returns a random page from all stored advertisements.
- The main page gets advertisements from that endpoint.
- Spring Cache is enabled and connected to that endpoint workflow.
- The endpoint is covered by end2end and integration tests. 